### PR TITLE
Implement Firebase auth with persistence

### DIFF
--- a/firebase.js
+++ b/firebase.js
@@ -1,6 +1,7 @@
 // Import the functions you need from the SDKs you need
 import { initializeApp } from "firebase/app";
 import { getFirestore } from "firebase/firestore";
+import { getAuth } from "firebase/auth";
 // TODO: Add SDKs for Firebase products that you want to use
 // https://firebase.google.com/docs/web/setup#available-libraries
 
@@ -17,5 +18,6 @@ const firebaseConfig = {
 // Initialize Firebase
 const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
+const auth = getAuth(app);
 
-export { db };
+export { db, auth };

--- a/src/components/RequireAuth.tsx
+++ b/src/components/RequireAuth.tsx
@@ -1,0 +1,19 @@
+import { Navigate } from "react-router-dom";
+import type { FC, PropsWithChildren } from "react";
+import { useAuth } from "../context/AuthContext";
+
+const RequireAuth: FC<PropsWithChildren> = ({ children }) => {
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return null;
+  }
+
+  if (!user) {
+    return <Navigate to="/authentication/sign-in" replace />;
+  }
+
+  return <>{children}</>;
+};
+
+export default RequireAuth;

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -1,6 +1,7 @@
 import { Sidebar, TextInput } from "flowbite-react";
 import type { FC } from "react";
 import { useEffect, useState } from "react";
+import { useAuth } from "../context/AuthContext";
 import {
   HiChartBar,
   HiChartPie,
@@ -16,6 +17,7 @@ import {
 } from "react-icons/hi";
 
 const ExampleSidebar: FC = function () {
+  const { logout } = useAuth();
   const [currentPage, setCurrentPage] = useState("");
 
   useEffect(() => {
@@ -83,7 +85,14 @@ const ExampleSidebar: FC = function () {
               >
                 Account Setiings
               </Sidebar.Item>
-              <Sidebar.Item href="/authentication/sign-up" icon={HiPencil}>
+              <Sidebar.Item
+                href="#"
+                icon={HiPencil}
+                onClick={(e) => {
+                  e.preventDefault();
+                  logout();
+                }}
+              >
                 Logout
               </Sidebar.Item>
             </Sidebar.ItemGroup>

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,62 @@
+import React, { createContext, useContext, useEffect, useState, PropsWithChildren } from "react";
+import { auth } from "../../firebase";
+import { User, onAuthStateChanged, signInWithEmailAndPassword, createUserWithEmailAndPassword, signOut } from "firebase/auth";
+
+interface AuthContextType {
+  user: User | null;
+  loading: boolean;
+  signIn: (email: string, password: string) => Promise<void>;
+  signUp: (email: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const useAuth = () => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error("useAuth must be used within AuthProvider");
+  }
+  return ctx;
+};
+
+export const AuthProvider = ({ children }: PropsWithChildren) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, (currentUser) => {
+      setUser(currentUser);
+      setLoading(false);
+      if (currentUser) {
+        localStorage.setItem(
+          "authUser",
+          JSON.stringify({ uid: currentUser.uid, email: currentUser.email })
+        );
+      } else {
+        localStorage.removeItem("authUser");
+      }
+    });
+    return unsub;
+  }, []);
+
+  const signIn = async (email: string, password: string) => {
+    await signInWithEmailAndPassword(auth, email, password);
+  };
+
+  const signUp = async (email: string, password: string) => {
+    await createUserWithEmailAndPassword(auth, email, password);
+  };
+
+  const logout = async () => {
+    await signOut(auth);
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, loading, signIn, signUp, logout }}>
+      {!loading && children}
+    </AuthContext.Provider>
+  );
+};
+
+export default AuthContext;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,8 @@ import theme from "./flowbite-theme";
 import { Flowbite } from "flowbite-react";
 import { Routes, Route } from "react-router";
 import { BrowserRouter } from "react-router-dom";
+import { AuthProvider } from "./context/AuthContext";
+import RequireAuth from "./components/RequireAuth";
 import DashboardPage from "./pages";
 import SignInPage from "./pages/authentication/sign-in";
 import SignUpPage from "./pages/authentication/sign-up";
@@ -25,17 +27,45 @@ root.render(
   <StrictMode>
     <Flowbite theme={{ theme }}>
       <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<DashboardPage />} index />
-          <Route path="/authentication/sign-in" element={<SignInPage />} />
-          <Route path="/authentication/sign-up" element={<SignUpPage />} />
-          <Route
-            path="/e-commerce/products"
-            element={<EcommerceProductsPage />}
-          />
-          <Route path="/users/list" element={<UserListPage />} />
-          <Route path="/billing" element={<BillingPage />} />
-        </Routes>
+        <AuthProvider>
+          <Routes>
+            <Route
+              path="/"
+              element={
+                <RequireAuth>
+                  <DashboardPage />
+                </RequireAuth>
+              }
+              index
+            />
+            <Route path="/authentication/sign-in" element={<SignInPage />} />
+            <Route path="/authentication/sign-up" element={<SignUpPage />} />
+            <Route
+              path="/e-commerce/products"
+              element={
+                <RequireAuth>
+                  <EcommerceProductsPage />
+                </RequireAuth>
+              }
+            />
+            <Route
+              path="/users/list"
+              element={
+                <RequireAuth>
+                  <UserListPage />
+                </RequireAuth>
+              }
+            />
+            <Route
+              path="/billing"
+              element={
+                <RequireAuth>
+                  <BillingPage />
+                </RequireAuth>
+              }
+            />
+          </Routes>
+        </AuthProvider>
       </BrowserRouter>
     </Flowbite>
   </StrictMode>

--- a/src/pages/authentication/sign-in.tsx
+++ b/src/pages/authentication/sign-in.tsx
@@ -1,8 +1,22 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import { Button, Card, Checkbox, Label, TextInput } from "flowbite-react";
-import type { FC } from "react";
+import type { FC, FormEvent } from "react";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../../context/AuthContext";
 
 const SignInPage: FC = function () {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const { signIn } = useAuth();
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    await signIn(email, password);
+    navigate("/");
+  };
+
   return (
     <div className="flex flex-col items-center justify-center px-6 lg:h-screen lg:gap-y-12">
       <div className="my-6 flex items-center gap-x-1 lg:my-0">
@@ -24,7 +38,7 @@ const SignInPage: FC = function () {
         <h1 className="mb-3 text-2xl font-bold dark:text-white md:text-3xl">
           Sign in to platform
         </h1>
-        <form>
+        <form onSubmit={handleSubmit}>
           <div className="mb-4 flex flex-col gap-y-3">
             <Label htmlFor="email">Your email</Label>
             <TextInput
@@ -32,6 +46,8 @@ const SignInPage: FC = function () {
               name="email"
               placeholder="name@company.com"
               type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
             />
           </div>
           <div className="mb-6 flex flex-col gap-y-3">
@@ -41,6 +57,8 @@ const SignInPage: FC = function () {
               name="password"
               placeholder="••••••••"
               type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
             />
           </div>
           <div className="mb-6 flex items-center justify-between">

--- a/src/pages/authentication/sign-up.tsx
+++ b/src/pages/authentication/sign-up.tsx
@@ -1,8 +1,26 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import { Button, Card, Checkbox, Label, TextInput } from "flowbite-react";
-import type { FC } from "react";
+import type { FC, FormEvent } from "react";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../../context/AuthContext";
 
 const SignUpPage: FC = function () {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const { signUp } = useAuth();
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (password !== confirmPassword) {
+      return;
+    }
+    await signUp(email, password);
+    navigate("/");
+  };
+
   return (
     <div className="flex flex-col items-center justify-center px-6 lg:h-screen lg:gap-y-12">
       <div className="my-6 flex items-center gap-x-1 lg:my-0">
@@ -24,7 +42,7 @@ const SignUpPage: FC = function () {
         <h1 className="mb-3 text-2xl font-bold dark:text-white md:text-3xl">
           Create a Free Account
         </h1>
-        <form>
+        <form onSubmit={handleSubmit}>
           <div className="mb-4 flex flex-col gap-y-3">
             <Label htmlFor="email">Your email</Label>
             <TextInput
@@ -32,6 +50,8 @@ const SignUpPage: FC = function () {
               name="email"
               placeholder="name@company.com"
               type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
             />
           </div>
           <div className="mb-6 flex flex-col gap-y-3">
@@ -41,6 +61,8 @@ const SignUpPage: FC = function () {
               name="password"
               placeholder="••••••••"
               type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
             />
           </div>
           <div className="mb-6 flex flex-col gap-y-3">
@@ -50,6 +72,8 @@ const SignUpPage: FC = function () {
               name="confirmPassword"
               placeholder="••••••••"
               type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
             />
           </div>
           <div className="mb-6 flex items-center gap-x-3">


### PR DESCRIPTION
## Summary
- enable Firebase auth services
- create Auth context and helper middleware
- implement login & sign-up functionality
- guard routes with authentication
- add logout action in sidebar

## Testing
- `yarn lint` *(fails: package missing in lockfile)*
- `yarn typecheck` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_684ee4d596b0832d87f4a87418da4227