### PR TITLE
Add meter man UI restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,12 @@ However, `react-router` needs your server to send all requests to `/`. This is c
 Most, but not all, providers have a mechanism to do this, but we can't cover them all here.
 
 Alternatively, you can change this app to server-side render. `vite` isn't designed to do that, so you'll need to use a plugin to create an HTML file for each page. `vite` [has a section in their docs](https://github.com/vitejs/awesome-vite#ssr) about SSR plugins and they seem great.
+
+## Demo Accounts
+
+The following accounts are available for testing the application:
+
+- **Teller**: `teller@gmail.com` / `teller123`
+- **Meter man**: `meterman@gmail.com` / `meter123`
+
+Logging in with the meter man account redirects directly to the billing dashboard. When logged in as the meter man only the billing section is visible and paying bills is disabled.

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -24,6 +24,9 @@ const ExampleSidebar: FC = function () {
     setCurrentPage(newPage);
   }, [setCurrentPage]);
 
+  const role = localStorage.getItem("role");
+  const isMeter = role === "meter";
+
   return (
     <Sidebar aria-label="Sidebar with multi-level dropdown example">
       <div className="flex h-full flex-col justify-between py-2">
@@ -39,15 +42,17 @@ const ExampleSidebar: FC = function () {
           </form>
           <Sidebar.Items>
             <Sidebar.ItemGroup>
-              <Sidebar.Item
-                href="/"
-                icon={HiChartPie}
-                className={
-                  "/" === currentPage ? "bg-gray-100 dark:bg-gray-700" : ""
-                }
-              >
-                Dashboard
-              </Sidebar.Item>
+              {!isMeter && (
+                <Sidebar.Item
+                  href="/"
+                  icon={HiChartPie}
+                  className={
+                    "/" === currentPage ? "bg-gray-100 dark:bg-gray-700" : ""
+                  }
+                >
+                  Dashboard
+                </Sidebar.Item>
+              )}
               <Sidebar.Item
                 href="/billing"
                 icon={HiChartBar}
@@ -59,36 +64,55 @@ const ExampleSidebar: FC = function () {
               >
                 Billing Management
               </Sidebar.Item>
-              <Sidebar.Item
-                href="/users/list"
-                icon={HiUsers}
-                className={
-                  "/users/list" === currentPage
-                    ? "bg-gray-100 dark:bg-gray-700"
-                    : ""
-                }
-              >
-                Customer List
-              </Sidebar.Item>
+              {!isMeter && (
+                <Sidebar.Item
+                  href="/users/list"
+                  icon={HiUsers}
+                  className={
+                    "/users/list" === currentPage
+                      ? "bg-gray-100 dark:bg-gray-700"
+                      : ""
+                  }
+                >
+                  Customer List
+                </Sidebar.Item>
+              )}
             </Sidebar.ItemGroup>
-            <Sidebar.ItemGroup>
-              <Sidebar.Item
-                href="https://github.com/themesberg/flowbite-react/"
-                icon={HiClipboard}
-              >
-                Generate Reports
-              </Sidebar.Item>
+            {!isMeter && (
+              <Sidebar.ItemGroup>
+                <Sidebar.Item
+                  href="https://github.com/themesberg/flowbite-react/"
+                  icon={HiClipboard}
+                >
+                  Generate Reports
+                </Sidebar.Item>
 
-              <Sidebar.Item
-                href="https://github.com/themesberg/flowbite-react/issues"
-                icon={HiInformationCircle}
-              >
-                Account Setiings
-              </Sidebar.Item>
-              <Sidebar.Item href="/" icon={HiPencil}>
-                Logout
-              </Sidebar.Item>
-            </Sidebar.ItemGroup>
+                <Sidebar.Item
+                  href="https://github.com/themesberg/flowbite-react/issues"
+                  icon={HiInformationCircle}
+                >
+                  Account Setiings
+                </Sidebar.Item>
+                <Sidebar.Item
+                  href="/"
+                  icon={HiPencil}
+                  onClick={() => localStorage.removeItem("role")}
+                >
+                  Logout
+                </Sidebar.Item>
+              </Sidebar.ItemGroup>
+            )}
+            {isMeter && (
+              <Sidebar.ItemGroup>
+                <Sidebar.Item
+                  href="/"
+                  icon={HiPencil}
+                  onClick={() => localStorage.removeItem("role")}
+                >
+                  Logout
+                </Sidebar.Item>
+              </Sidebar.ItemGroup>
+            )}
           </Sidebar.Items>
         </div>
       </div>

--- a/src/pages/authentication/sign-in.tsx
+++ b/src/pages/authentication/sign-in.tsx
@@ -15,7 +15,12 @@ const SignInPage: FC = function () {
       .value;
 
     if (email === "teller@gmail.com" && password === "teller123") {
+      localStorage.setItem("role", "teller");
       window.location.href = "/dashboard";
+      setError("");
+    } else if (email === "meterman@gmail.com" && password === "meter123") {
+      localStorage.setItem("role", "meter");
+      window.location.href = "/billing";
       setError("");
     } else {
       setError("Invalid email or password.");
@@ -27,7 +32,7 @@ const SignInPage: FC = function () {
       className="flex min-h-screen items-center justify-center bg-cover bg-center px-4"
       style={{
         backgroundImage:
-          "linear-gradient(rgba(15, 23, 42, 0.85), rgba(15, 23, 42, 0.85)), url('https://images.unsplash.com/photo-1503264116251-35a269479413?auto=format&fit=crop&w=1950&q=80')",
+          "linear-gradient(rgba(15, 23, 42, 0.95), rgba(15, 23, 42, 0.95)), url('https://images.unsplash.com/photo-1503264116251-35a269479413?auto=format&fit=crop&w=1950&q=80')",
       }}
     >
       <div className="w-full max-w-md">

--- a/src/pages/billing/list.tsx
+++ b/src/pages/billing/list.tsx
@@ -348,7 +348,9 @@ const BillingUsersTable: FC<BillingUsersTableProps> = ({ users }) => (
           </Table.Cell>
           <Table.Cell className="p-4 space-x-2 flex">
             <BillModal userId={user.id} />
-            <PayBillingModal userId={user.id} />
+            {localStorage.getItem("role") !== "meter" && (
+              <PayBillingModal userId={user.id} />
+            )}
           </Table.Cell>
         </Table.Row>
       ))}


### PR DESCRIPTION
## Summary
- restrict sidebar links based on logged in role
- disable bill paying for meter man
- store user role in localStorage during login
- darken sign in background overlay
- document meter man limitations

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn install --frozen-lockfile` *(fails: network 403)*
- `yarn typecheck` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_684ee9373dfc832d8fd507389d299ae8