### PR TITLE
Persist theme preference

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react";
-import { Button, DarkThemeToggle, Navbar } from "flowbite-react";
+import { Button, Navbar } from "flowbite-react";
+import ThemeToggle from "./theme-toggle";
 
 const ExampleNavbar: FC = function () {
   return (
@@ -19,7 +20,7 @@ const ExampleNavbar: FC = function () {
             </Navbar.Brand>
           </div>
           <div className="flex items-center gap-3">
-            <DarkThemeToggle />
+            <ThemeToggle />
           </div>
         </div>
       </div>

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,34 @@
+import { DarkThemeToggle } from "flowbite-react";
+import type { FC } from "react";
+import { useEffect, useState } from "react";
+
+const ThemeToggle: FC = function () {
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme");
+    if (stored === "dark") {
+      document.documentElement.classList.add("dark");
+      setIsDark(true);
+    } else if (stored === "light") {
+      document.documentElement.classList.remove("dark");
+      setIsDark(false);
+    }
+  }, []);
+
+  const toggleTheme = () => {
+    const dark = !isDark;
+    setIsDark(dark);
+    if (dark) {
+      document.documentElement.classList.add("dark");
+      localStorage.setItem("theme", "dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+      localStorage.setItem("theme", "light");
+    }
+  };
+
+  return <DarkThemeToggle onClick={toggleTheme} />;
+};
+
+export default ThemeToggle;


### PR DESCRIPTION
## Summary
- add new `ThemeToggle` component that stores theme in `localStorage`
- use `ThemeToggle` in navbar

## Testing
- `yarn lint` *(fails: package doesn't seem to be present in lockfile)*
- `yarn build` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_684eee084564832db63cd4d595f0c98a