### PR TITLE
Add reports page with react-pdf

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "flowbite": "^1.5.5",
     "flowbite-react": "^0.3.7",
     "react-apexcharts": "^1.4.0",
-    "react-icons": "^4.7.1"
+    "react-icons": "^4.7.1",
+    "@react-pdf/renderer": "^3.3.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.26",

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -83,8 +83,13 @@ const ExampleSidebar: FC = function () {
             {!isMeter && (
               <Sidebar.ItemGroup>
                 <Sidebar.Item
-                  href="https://github.com/themesberg/flowbite-react/"
+                  href="/reports"
                   icon={HiClipboard}
+                  className={
+                    "/reports" === currentPage
+                      ? "bg-gray-100 dark:bg-gray-700"
+                      : ""
+                  }
                 >
                   Generate Reports
                 </Sidebar.Item>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,6 +12,7 @@ import SignUpPage from "./pages/authentication/sign-up";
 import EcommerceProductsPage from "./pages/e-commerce/products";
 import UserListPage from "./pages/users/list";
 import BillingPage from "./pages/billing/list";
+import ReportsPage from "./pages/reports";
 
 const container = document.getElementById("root");
 
@@ -34,6 +35,7 @@ root.render(
           />
           <Route path="/users/list" element={<UserListPage />} />
           <Route path="/billing" element={<BillingPage />} />
+          <Route path="/reports" element={<ReportsPage />} />
         </Routes>
       </BrowserRouter>
     </Flowbite>

--- a/src/pages/reports/index.tsx
+++ b/src/pages/reports/index.tsx
@@ -1,0 +1,70 @@
+import { Breadcrumb, Button } from "flowbite-react";
+import type { FC } from "react";
+import { useEffect, useState } from "react";
+import { PDFDownloadLink, Document, Page, Text, StyleSheet } from "@react-pdf/renderer";
+import NavbarSidebarLayout from "../../layouts/navbar-sidebar";
+import useCrudBill from "../../hooks/useCrudBill";
+import { HiHome } from "react-icons/hi";
+
+interface Bill {
+  id: string;
+  userId: string;
+  month: string;
+  prevReading: number;
+  currentReading: number;
+  amount: string;
+  deadline: string;
+  paidDate?: string;
+}
+
+const styles = StyleSheet.create({
+  page: { padding: 20 },
+  title: { fontSize: 18, marginBottom: 10, textAlign: "center" },
+  section: { marginBottom: 5 },
+});
+
+const ReportsPage: FC = function () {
+  const [bills, setBills] = useState<Bill[]>([]);
+  const { getBills } = useCrudBill();
+
+  useEffect(() => {
+    getBills(setBills);
+  }, []);
+
+  const doc = (
+    <Document>
+      <Page size="A4" style={styles.page}>
+        <Text style={styles.title}>Billing Report</Text>
+        {bills.map((bill) => (
+          <Text key={bill.id} style={styles.section}>
+            {bill.month} - {bill.prevReading} - {bill.currentReading} - ${bill.amount}
+          </Text>
+        ))}
+      </Page>
+    </Document>
+  );
+
+  return (
+    <NavbarSidebarLayout isFooter={false}>
+      <div className="border-b border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+        <Breadcrumb className="mb-2">
+          <Breadcrumb.Item href="#">
+            <HiHome className="text-xl mr-2" />
+            <span className="dark:text-white">Home</span>
+          </Breadcrumb.Item>
+          <Breadcrumb.Item>Reports</Breadcrumb.Item>
+        </Breadcrumb>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Generate Reports</h1>
+      </div>
+      <div className="p-4">
+        <PDFDownloadLink document={doc} fileName="report.pdf">
+          {({ loading }) => (
+            <Button>{loading ? "Loading document..." : "Download PDF"}</Button>
+          )}
+        </PDFDownloadLink>
+      </div>
+    </NavbarSidebarLayout>
+  );
+};
+
+export default ReportsPage;


### PR DESCRIPTION
## Summary
- add @react-pdf/renderer dependency
- add sidebar link to `/reports`
- create reports page that generates a PDF
- register `/reports` route

## Testing
- `yarn lint` *(fails: package doesn't seem to be present in lockfile)*
- `yarn typecheck` *(fails: package doesn't seem to be present in lockfile)*


------
https://chatgpt.com/codex/tasks/task_b_684f79bfbf7c832d8d355807262f9c4c