### PR TITLE
Add mobile responsive sidebar

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,7 +1,12 @@
 import type { FC } from "react";
 import { DarkThemeToggle, Navbar } from "flowbite-react";
+import { HiMenu } from "react-icons/hi";
 
-const ExampleNavbar: FC = function () {
+interface ExampleNavbarProps {
+  onSidebarToggle: () => void;
+}
+
+const ExampleNavbar: FC<ExampleNavbarProps> = function ({ onSidebarToggle }) {
   const role = localStorage.getItem("role");
   const isMeter = role === "meter";
 
@@ -9,21 +14,29 @@ const ExampleNavbar: FC = function () {
     <Navbar fluid className="bg-[#23404B] shadow-md">
       <div className="w-full px-4 py-3 lg:px-6 text-white">
         <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between">
-          {/* Left: Logo and Branding */}
-          <Navbar.Brand
-            href="/"
-            className="flex items-center space-x-3 hover:opacity-90"
-          >
-            <img alt="Logo" src="/images/logo.png" className="h-8 sm:h-10" />
-            <div>
-              <div className="text-xl font-semibold leading-tight">
-                Water District
+          {/* Left: Toggle & Branding */}
+          <div className="flex items-center justify-between lg:justify-start lg:gap-4">
+            <button
+              className="mr-2 rounded text-white focus:outline-none lg:hidden"
+              onClick={onSidebarToggle}
+            >
+              <HiMenu className="h-6 w-6" />
+            </button>
+            <Navbar.Brand
+              href="/"
+              className="flex items-center space-x-3 hover:opacity-90"
+            >
+              <img alt="Logo" src="/images/logo.png" className="h-8 sm:h-10" />
+              <div>
+                <div className="text-xl font-semibold leading-tight">
+                  Water District
+                </div>
+                <div className="text-xs text-gray-300">
+                  Villanueva, Misamis Oriental
+                </div>
               </div>
-              <div className="text-xs text-gray-300">
-                Villanueva, Misamis Oriental
-              </div>
-            </div>
-          </Navbar.Brand>
+            </Navbar.Brand>
+          </div>
 
           {/* Right: Role & Toggle */}
           <div className="mt-3 flex items-center justify-between gap-4 lg:mt-0">

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -7,6 +7,7 @@ import {
   HiClipboard,
   HiCollection,
   HiCurrencyDollar,
+  HiX,
   HiInformationCircle,
   HiLogin,
   HiPencil,
@@ -15,7 +16,12 @@ import {
   HiUsers,
 } from "react-icons/hi";
 
-const ExampleSidebar: FC = function () {
+interface SidebarProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const ExampleSidebar: FC<SidebarProps> = function ({ isOpen, onClose }) {
   const [currentPage, setCurrentPage] = useState("");
 
   useEffect(() => {
@@ -28,7 +34,18 @@ const ExampleSidebar: FC = function () {
   const isMeter = role === "meter";
 
   return (
-    <Sidebar aria-label="Sidebar with multi-level dropdown example">
+    <Sidebar
+      aria-label="Sidebar with multi-level dropdown example"
+      className={`fixed top-0 left-0 z-40 h-screen w-64 transition-transform bg-white dark:bg-gray-800 lg:static lg:translate-x-0 ${
+        isOpen ? "translate-x-0" : "-translate-x-full"
+      }`}
+    >
+      <button
+        onClick={onClose}
+        className="absolute top-2 right-2 rounded p-1 text-gray-500 hover:bg-gray-100 lg:hidden"
+      >
+        <HiX className="h-5 w-5" />
+      </button>
       <div className="flex h-full flex-col justify-between py-2">
         <div>
           <form className="pb-3 md:hidden">

--- a/src/layouts/navbar-sidebar.tsx
+++ b/src/layouts/navbar-sidebar.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { FC, PropsWithChildren } from "react";
 import Navbar from "../components/navbar";
 import Sidebar from "../components/sidebar";
@@ -8,11 +9,19 @@ interface NavbarSidebarLayoutProps {
 
 const NavbarSidebarLayout: FC<PropsWithChildren<NavbarSidebarLayoutProps>> =
   function ({ children, isFooter = true }) {
+    const [isSidebarOpen, setSidebarOpen] = useState(false);
+
     return (
       <>
-        <Navbar />
+        <Navbar onSidebarToggle={() => setSidebarOpen((prev) => !prev)} />
+        {isSidebarOpen && (
+          <div
+            className="fixed inset-0 z-30 bg-black/50 lg:hidden"
+            onClick={() => setSidebarOpen(false)}
+          />
+        )}
         <div className="flex items-start pt-16">
-          <Sidebar />
+          <Sidebar isOpen={isSidebarOpen} onClose={() => setSidebarOpen(false)} />
           <MainContent isFooter={isFooter}>{children}</MainContent>
         </div>
       </>

--- a/src/pages/billing/list.tsx
+++ b/src/pages/billing/list.tsx
@@ -379,7 +379,7 @@ const PayBillingModal: FC<PayBillingModalProps> = ({ userId }) => {
 };
 
 const BillingUsersTable: FC<BillingUsersTableProps> = ({ users }) => (
-  <Table className="min-w-full divide-y divide-gray-200 dark:divide-gray-600">
+  <Table className="min-w-full w-full divide-y divide-gray-200 dark:divide-gray-600">
     <Table.Head className="bg-gray-50 dark:bg-gray-800">
       <Table.HeadCell className="text-sm font-semibold text-gray-700 dark:text-gray-300">
         Name

--- a/src/pages/e-commerce/products.tsx
+++ b/src/pages/e-commerce/products.tsx
@@ -86,7 +86,7 @@ const EcommerceProductsPage: FC = function () {
       </div>
       <div className="flex flex-col">
         <div className="overflow-x-auto">
-          <div className="inline-block min-w-full align-middle">
+          <div className="inline-block min-w-full w-full align-middle">
             <div className="overflow-hidden shadow">
               <ProductsTable />
             </div>
@@ -369,7 +369,7 @@ const DeleteProductModal: FC = function () {
 
 const ProductsTable: FC = function () {
   return (
-    <Table className="min-w-full divide-y divide-gray-200 dark:divide-gray-600">
+    <Table className="min-w-full w-full divide-y divide-gray-200 dark:divide-gray-600">
       <Table.Head className="bg-gray-100 dark:bg-gray-700">
         <Table.HeadCell>
           <span className="sr-only">Toggle selected</span>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -269,11 +269,11 @@ const LatestTransactions: FC = function () {
       </div>
       <div className="mt-8 flex flex-col">
         <div className="overflow-x-auto rounded-lg">
-          <div className="inline-block min-w-full align-middle">
+          <div className="inline-block min-w-full w-full align-middle">
             <div className="overflow-hidden shadow sm:rounded-lg">
               <Table
                 striped
-                className="min-w-full divide-y divide-gray-200 dark:divide-gray-600"
+                className="min-w-full w-full divide-y divide-gray-200 dark:divide-gray-600"
               >
                 <Table.Head className="bg-gray-50 dark:bg-gray-700">
                   <Table.HeadCell>Transaction</Table.HeadCell>

--- a/src/pages/users/list.tsx
+++ b/src/pages/users/list.tsx
@@ -92,7 +92,7 @@ const UserListPage: FC = function () {
       </div>
       <div className="flex flex-col">
         <div className="overflow-x-auto">
-          <div className="inline-block min-w-full align-middle">
+          <div className="inline-block min-w-full w-full align-middle">
             <div className="overflow-hidden shadow">
               <AllUsersTable />
             </div>
@@ -262,7 +262,7 @@ const AllUsersTable: FC = function () {
   }, []);
 
   return (
-    <Table className="min-w-full divide-y divide-gray-200 dark:divide-gray-600">
+    <Table className="min-w-full w-full divide-y divide-gray-200 dark:divide-gray-600">
       <Table.Head className="bg-gray-100 dark:bg-gray-700">
         <Table.HeadCell>Name</Table.HeadCell>
         <Table.HeadCell>Meter ID</Table.HeadCell>


### PR DESCRIPTION
## Summary
- enable toggling of sidebar via mobile menu
- overlay background for sidebar on small screens
- add sidebar close button

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*
- `npm run typecheck` *(fails: Cannot find type definition file for 'vite/client')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_685f592e93c0832db7b4b83bf53547c8