### PR TITLE
Add reports page and password update

### DIFF
--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -99,18 +99,15 @@ const ExampleSidebar: FC<SidebarProps> = function ({ isOpen, onClose }) {
             </Sidebar.ItemGroup>
             {!isMeter && (
               <Sidebar.ItemGroup>
-                <Sidebar.Item
-                  href="https://github.com/themesberg/flowbite-react/"
-                  icon={HiClipboard}
-                >
+                <Sidebar.Item href="/reports" icon={HiClipboard}>
                   Generate Reports
                 </Sidebar.Item>
 
                 <Sidebar.Item
-                  href="https://github.com/themesberg/flowbite-react/issues"
+                  href="/account/settings"
                   icon={HiInformationCircle}
                 >
-                  Account Setiings
+                  Account Settings
                 </Sidebar.Item>
                 <Sidebar.Item
                   href="/"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,6 +12,8 @@ import SignUpPage from "./pages/authentication/sign-up";
 import EcommerceProductsPage from "./pages/e-commerce/products";
 import UserListPage from "./pages/users/list";
 import BillingPage from "./pages/billing/list";
+import ReportsPage from "./pages/reports";
+import AccountSettingsPage from "./pages/account/settings";
 
 const container = document.getElementById("root");
 
@@ -34,8 +36,10 @@ root.render(
           />
           <Route path="/users/list" element={<UserListPage />} />
           <Route path="/billing" element={<BillingPage />} />
+          <Route path="/reports" element={<ReportsPage />} />
+          <Route path="/account/settings" element={<AccountSettingsPage />} />
         </Routes>
       </BrowserRouter>
     </Flowbite>
-  </StrictMode>
+  </StrictMode>,
 );

--- a/src/pages/account/settings.tsx
+++ b/src/pages/account/settings.tsx
@@ -1,0 +1,126 @@
+import { Breadcrumb, Button, Label, TextInput } from "flowbite-react";
+import type { FC, FormEvent } from "react";
+import { useEffect, useState } from "react";
+import { HiHome } from "react-icons/hi";
+import NavbarSidebarLayout from "../../layouts/navbar-sidebar";
+
+interface Account {
+  email: string;
+  password: string;
+  role: string;
+}
+
+const AccountSettingsPage: FC = function () {
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+  const [account, setAccount] = useState<Account | null>(null);
+
+  useEffect(() => {
+    const role = localStorage.getItem("role");
+    const stored = localStorage.getItem("accounts");
+    if (role && stored) {
+      try {
+        const accounts: Account[] = JSON.parse(stored);
+        const acc = accounts.find((a) => a.role === role) || null;
+        setAccount(acc);
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }, []);
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!account) return;
+    setError("");
+    setSuccess("");
+    if (currentPassword !== account.password) {
+      setError("Current password is incorrect.");
+      return;
+    }
+    if (!newPassword || newPassword !== confirmPassword) {
+      setError("New passwords do not match.");
+      return;
+    }
+
+    const stored = localStorage.getItem("accounts");
+    if (stored) {
+      try {
+        const accounts: Account[] = JSON.parse(stored);
+        const idx = accounts.findIndex((a) => a.role === account.role);
+        if (idx !== -1) {
+          accounts[idx].password = newPassword;
+          localStorage.setItem("accounts", JSON.stringify(accounts));
+          setAccount(accounts[idx]);
+          setSuccess("Password updated successfully.");
+          setCurrentPassword("");
+          setNewPassword("");
+          setConfirmPassword("");
+        }
+      } catch {
+        setError("Unable to update password.");
+      }
+    }
+  };
+
+  return (
+    <NavbarSidebarLayout>
+      <div className="border-b border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+        <div className="mb-4">
+          <Breadcrumb className="mb-2">
+            <Breadcrumb.Item href="#">
+              <HiHome className="text-xl mr-2" />
+              <span className="dark:text-white">Home</span>
+            </Breadcrumb.Item>
+            <Breadcrumb.Item>Account Settings</Breadcrumb.Item>
+          </Breadcrumb>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+            Account Settings
+          </h1>
+        </div>
+      </div>
+      <div className="p-4 sm:p-6">
+        <form onSubmit={handleSubmit} className="max-w-md space-y-4">
+          <div>
+            <Label htmlFor="current" value="Current Password" />
+            <TextInput
+              id="current"
+              type="password"
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+              required
+            />
+          </div>
+          <div>
+            <Label htmlFor="new" value="New Password" />
+            <TextInput
+              id="new"
+              type="password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              required
+            />
+          </div>
+          <div>
+            <Label htmlFor="confirm" value="Confirm New Password" />
+            <TextInput
+              id="confirm"
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              required
+            />
+          </div>
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          {success && <p className="text-sm text-green-600">{success}</p>}
+          <Button type="submit">Update Password</Button>
+        </form>
+      </div>
+    </NavbarSidebarLayout>
+  );
+};
+
+export default AccountSettingsPage;

--- a/src/pages/authentication/sign-in.tsx
+++ b/src/pages/authentication/sign-in.tsx
@@ -1,11 +1,30 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button, Card, Checkbox, Label, TextInput } from "flowbite-react";
 import type { FC, FormEvent } from "react";
 import logo from "../../../public/images/logo.png";
 
+const defaultAccounts = [
+  { email: "teller@gmail.com", password: "teller123", role: "teller" },
+  { email: "meterman@gmail.com", password: "meter123", role: "meter" },
+];
+
 const SignInPage: FC = function () {
   const [error, setError] = useState("");
+  const [accounts, setAccounts] = useState(defaultAccounts);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("accounts");
+    if (stored) {
+      try {
+        setAccounts(JSON.parse(stored));
+      } catch {
+        setAccounts(defaultAccounts);
+      }
+    } else {
+      localStorage.setItem("accounts", JSON.stringify(defaultAccounts));
+    }
+  }, []);
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -14,13 +33,17 @@ const SignInPage: FC = function () {
     const password = (form.elements.namedItem("password") as HTMLInputElement)
       .value;
 
-    if (email === "teller@gmail.com" && password === "teller123") {
-      localStorage.setItem("role", "teller");
-      window.location.href = "/dashboard";
-      setError("");
-    } else if (email === "meterman@gmail.com" && password === "meter123") {
-      localStorage.setItem("role", "meter");
-      window.location.href = "/billing";
+    const account = accounts.find(
+      (a) => a.email === email && a.password === password,
+    );
+
+    if (account) {
+      localStorage.setItem("role", account.role);
+      if (account.role === "meter") {
+        window.location.href = "/billing";
+      } else {
+        window.location.href = "/dashboard";
+      }
       setError("");
     } else {
       setError("Invalid email or password.");

--- a/src/pages/reports.tsx
+++ b/src/pages/reports.tsx
@@ -1,0 +1,92 @@
+import { Breadcrumb, Table } from "flowbite-react";
+import type { FC } from "react";
+import { useEffect, useState } from "react";
+import { HiHome } from "react-icons/hi";
+import NavbarSidebarLayout from "../layouts/navbar-sidebar";
+import useCrudBill from "../hooks/useCrudBill";
+import useCrudUser from "../hooks/useCrudUser";
+
+interface Bill {
+  id: string;
+  userId: string;
+  month: string;
+  prevReading: number;
+  currentReading: number;
+  amount: string;
+  deadline: string;
+  paidDate?: string;
+}
+
+interface User {
+  id: string;
+  firstName: string;
+  lastName: string;
+}
+
+const ReportsPage: FC = function () {
+  const [bills, setBills] = useState<Bill[]>([]);
+  const [users, setUsers] = useState<User[]>([]);
+  const { getBills } = useCrudBill();
+  const { getUsers } = useCrudUser();
+
+  useEffect(() => {
+    getBills(setBills);
+    getUsers(setUsers);
+  }, []);
+
+  const userMap = new Map(users.map((u) => [u.id, u]));
+
+  return (
+    <NavbarSidebarLayout isFooter={false}>
+      <div className="border-b border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+        <div className="mb-4">
+          <Breadcrumb className="mb-2">
+            <Breadcrumb.Item href="#">
+              <HiHome className="text-xl mr-2" />
+              <span className="dark:text-white">Home</span>
+            </Breadcrumb.Item>
+            <Breadcrumb.Item>Generate Reports</Breadcrumb.Item>
+          </Breadcrumb>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+            Reports
+          </h1>
+        </div>
+      </div>
+      <div className="p-4 sm:p-6">
+        <div className="overflow-hidden rounded-lg shadow-md bg-white dark:bg-gray-800">
+          <Table hoverable striped>
+            <Table.Head>
+              <Table.HeadCell>Customer</Table.HeadCell>
+              <Table.HeadCell>Month</Table.HeadCell>
+              <Table.HeadCell>Prev</Table.HeadCell>
+              <Table.HeadCell>Current</Table.HeadCell>
+              <Table.HeadCell>Amount</Table.HeadCell>
+              <Table.HeadCell>Deadline</Table.HeadCell>
+              <Table.HeadCell>Paid Date</Table.HeadCell>
+            </Table.Head>
+            <Table.Body className="text-sm">
+              {bills.map((bill) => {
+                const u = userMap.get(bill.userId);
+                return (
+                  <Table.Row key={bill.id}>
+                    <Table.Cell>
+                      {u ? `${u.firstName} ${u.lastName}` : bill.userId}
+                    </Table.Cell>
+                    <Table.Cell>{bill.month}</Table.Cell>
+                    <Table.Cell>{bill.prevReading}</Table.Cell>
+                    <Table.Cell>{bill.currentReading}</Table.Cell>
+                    <Table.Cell>₱{bill.amount}</Table.Cell>
+                    <Table.Cell>{bill.deadline}</Table.Cell>
+                    <Table.Cell>{bill.paidDate || "-"}</Table.Cell>
+                  </Table.Row>
+                );
+              })}
+            </Table.Body>
+          </Table>
+        </div>
+      </div>
+    </NavbarSidebarLayout>
+  );
+};
+
+export default ReportsPage;


### PR DESCRIPTION
## Summary
- add dynamic account support in sign in
- create reports page to list bills
- add account settings page for changing password
- hook up routes and sidebar navigation

## Testing
- `npm run format`
- `npm run lint` *(fails: Invalid option '--ignore-path')*
- `npm run typecheck` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_b_685f5ea0f1fc832d8d3df2b5f62f3e19