### PR TITLE
Add receipt PDF generation in billing

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "flowbite": "^1.5.5",
     "flowbite-react": "^0.3.7",
     "react-apexcharts": "^1.4.0",
-    "react-icons": "^4.7.1"
+    "react-icons": "^4.7.1",
+    "react-to-pdf": "^0.0.14"
   },
   "devDependencies": {
     "@types/react": "^18.0.26",


### PR DESCRIPTION
## Summary
- allow viewing bills' receipt with ReactToPdf
- include react-to-pdf dependency

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path'...)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_b_685fb2a3cd58832d90023d5baee6f5e4