### PR TITLE
Auto-generate meter id when adding user

### DIFF
--- a/src/pages/users/list.tsx
+++ b/src/pages/users/list.tsx
@@ -124,6 +124,16 @@ const AddUserModal: FC = function () {
   const { addUser } = useCrudUser();
   const { addBill } = useCrudBill();
 
+  const generateMeterID = () => {
+    return Math.floor(100000000 + Math.random() * 900000000).toString();
+  };
+
+  useEffect(() => {
+    if (isOpen) {
+      setForms((prev) => ({ ...prev, meterID: generateMeterID() }));
+    }
+  }, [isOpen]);
+
   const handleChange = (value: string, name: string) => {
     const formsCopy = { ...forms };
     formsCopy[name] = value;
@@ -207,13 +217,13 @@ const AddUserModal: FC = function () {
               </div>
             </div>
             <div>
-              <Label htmlFor="department">Meter ID</Label>
+              <Label htmlFor="meterID">Meter ID</Label>
               <div className="mt-1">
                 <TextInput
-                  id="department"
+                  id="meterID"
                   name="meterID"
-                  placeholder="Development"
-                  onChange={(e) => handleChange(e.target.value, e.target.name)}
+                  value={forms.meterID}
+                  readOnly
                 />
               </div>
             </div>


### PR DESCRIPTION
## Summary
- generate a unique meter ID whenever the add user modal opens
- prevent editing the meter ID field

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path' due to eslint configuration)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'vite/client')*


------
https://chatgpt.com/codex/tasks/task_b_685ff2964d14832dbf17ba808dfdcfbf