### PR TITLE
Enable PDF download for billing receipts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "flowbite": "^1.5.5",
         "flowbite-react": "^0.3.7",
         "react-apexcharts": "^1.4.0",
-        "react-icons": "^4.7.1"
+        "react-icons": "^4.7.1",
+        "react-to-pdf": "^0.0.14"
       },
       "devDependencies": {
         "@types/react": "^18.0.26",
@@ -6713,6 +6714,15 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-to-pdf": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/react-to-pdf/-/react-to-pdf-0.0.14.tgz",
+      "integrity": "",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "flowbite": "^1.5.5",
     "flowbite-react": "^0.3.7",
     "react-apexcharts": "^1.4.0",
-    "react-icons": "^4.7.1"
+    "react-icons": "^4.7.1",
+    "react-to-pdf": "^0.0.14"
   },
   "devDependencies": {
     "@types/react": "^18.0.26",

--- a/src/pages/billing/list.tsx
+++ b/src/pages/billing/list.tsx
@@ -8,7 +8,8 @@ import {
   TextInput,
 } from "flowbite-react";
 import type { FC } from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
+import ReactToPdf from "react-to-pdf";
 import NavbarSidebarLayout from "../../layouts/navbar-sidebar";
 import useCrudUser from "../../hooks/useCrudUser";
 import { increment } from "firebase/firestore";
@@ -112,6 +113,7 @@ const BillModal: FC<BillModalProps> = ({ userId, connection, user }) => {
 
   const [showReceipt, setShowReceipt] = useState(false);
   const [selectedBill, setSelectedBill] = useState<Bill | null>(null);
+  const receiptRef = useRef<HTMLDivElement>(null);
 
   const consumption = selectedBill
     ? Math.max(selectedBill.currentReading - selectedBill.prevReading, 0)
@@ -190,13 +192,27 @@ const BillModal: FC<BillModalProps> = ({ userId, connection, user }) => {
         <Modal.Header>Billing Receipt</Modal.Header>
         <Modal.Body>
           {selectedBill ? (
-            <div className="wrapper flex justify-center items-center flex-col dark:text-white">
-              <div className="flex flex-col items-center justify-center">
-                <img width={130} src={logo} alt="" />
-                <div className="text-center mt-5">
-                  <h1>VILLANUEVA WATER SYSTEM</h1>
-                  <h1>LGU Villanueva {"\n"} Misamin, Oriental</h1>
-                </div>
+            <>
+              <ReactToPdf
+                targetRef={receiptRef}
+                filename={`receipt-${selectedBill.month}.pdf`}
+              >
+                {({ toPdf }) => (
+                  <Button onClick={toPdf} className="mb-4">
+                    Download PDF
+                  </Button>
+                )}
+              </ReactToPdf>
+              <div
+                ref={receiptRef}
+                className="wrapper flex justify-center items-center flex-col dark:text-white"
+              >
+                <div className="flex flex-col items-center justify-center">
+                  <img width={130} src={logo} alt="" />
+                  <div className="text-center mt-5">
+                    <h1>VILLANUEVA WATER SYSTEM</h1>
+                    <h1>LGU Villanueva {"\n"} Misamin, Oriental</h1>
+                  </div>
               </div>
               <div className="w-full mt-10">{formattedDateTime}</div>
               <h1>=============================</h1>
@@ -278,6 +294,7 @@ const BillModal: FC<BillModalProps> = ({ userId, connection, user }) => {
               </div>
               <h1>=============================</h1>
             </div>
+            </>
           ) : (
             <p>No data available.</p>
           )}


### PR DESCRIPTION
## Summary
- use `react-to-pdf` to save meter billing receipts
- add missing dependency

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*
- `npm run typecheck` *(fails: cannot find type definition 'vite/client')*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_685ff5cec7f0832d9ad6510be6d0a7ea