### PR TITLE
Autofill paid date

### DIFF
--- a/src/pages/billing/list.tsx
+++ b/src/pages/billing/list.tsx
@@ -511,6 +511,9 @@ const PayBillingModal: FC<PayBillingModalProps> = ({ userId, user }) => {
   useEffect(() => {
     if (isOpen) {
       getBillsByUser(userId, setBills);
+      // Default the paid date to today's date when the modal opens
+      const today = new Date().toISOString().slice(0, 10);
+      setDate(today);
     }
   }, [isOpen]);
 


### PR DESCRIPTION
## Summary
- autofill paid date to today's value when the Pay Billing modal opens

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*
- `npm run typecheck` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_b_68644337db54832db9a26afe65936e01