### PR TITLE
Add amount paid & change in billing

### DIFF
--- a/src/pages/billing/list.tsx
+++ b/src/pages/billing/list.tsx
@@ -679,6 +679,15 @@ const PayBillingModal: FC<PayBillingModalProps> = ({ userId, user }) => {
             />
           </div>
           <div className="mb-4">
+            <Label htmlFor="total" value="Total Amount" />
+            <TextInput
+              id="total"
+              readOnly
+              className="bg-gray-100 dark:bg-gray-700"
+              value={totalAmount.toFixed(2)}
+            />
+          </div>
+          <div className="mb-4">
             <Label htmlFor="amountPaid" value="Amount Paid" />
             <TextInput
               id="amountPaid"


### PR DESCRIPTION
## Summary
- add fields for amount paid & change in Pay Billing modal
- auto-fill paid date when opening modal

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*
- `npm run typecheck` *(fails: Cannot find type definition file for 'vite/client')*


------
https://chatgpt.com/codex/tasks/task_b_68660cf89d48832daaaa095466417378