### PR TITLE
Fix billing modal visibility

### DIFF
--- a/src/pages/billing/list.tsx
+++ b/src/pages/billing/list.tsx
@@ -351,7 +351,7 @@ const BillModal: FC<BillModalProps> = ({ userId, connection, user }) => {
       </Modal>
 
       <Modal onClose={() => setOpen(false)} show={isOpen} size="5xl">
-        <Modal.Header>Monthly Bills</Modal.Header>
+        <Modal.Header className="sticky top-0 z-50">Monthly Bills</Modal.Header>
         <Modal.Body>
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
             <div>
@@ -776,11 +776,13 @@ const BillingUsersTable: FC<BillingUsersTableProps> = ({ users }) => (
             </span>
           </Table.Cell>
           <Table.Cell className="p-4 flex flex-wrap gap-2">
-            <BillModal
-              userId={user.id}
-              user={user}
-              connection={user.connection}
-            />
+            {localStorage.getItem("role") === "meter" && (
+              <BillModal
+                userId={user.id}
+                user={user}
+                connection={user.connection}
+              />
+            )}
             {localStorage.getItem("role") !== "meter" && (
               <PayBillingModal user={user} userId={user.id} />
             )}


### PR DESCRIPTION
## Summary
- restrict BillModal to the meterman role only
- make billing modal header sticky so close button stays visible

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*
- `npm run typecheck` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_b_68660fe2cb44832dbea529c71a8a5691